### PR TITLE
Restore interrupted status for InterruptedException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,30 +36,42 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+
+		<slf4j.version>1.7.25</slf4j.version>
+		<lombok.version>1.16.16</lombok.version>
+		<junit.version>4.12</junit.version>
+		<harmcrest.version>1.3</harmcrest.version>
+		<mockito.version>2.8.9</mockito.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
+			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.16</version>
+			<version>${lombok.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<version>${harmcrest.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>2.8.9</version>
+			<version>${mockito.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/machinezoo/noexception/ExceptionHandler.java
+++ b/src/main/java/com/machinezoo/noexception/ExceptionHandler.java
@@ -63,6 +63,31 @@ public abstract class ExceptionHandler {
 	 * @see Exceptions
 	 */
 	public abstract boolean handle(Throwable exception);
+
+	/**
+	 * @return {@code true} when exception is handled, {@code false} if the exception should be rethrown
+	 */
+	boolean doHandle(Throwable exception) {
+		// Using of sneak() can hide an checked exception from the java-compiler and
+		// we may catch an checked exception here. So we must add special
+		// processing for InterruptedException
+		try {
+			boolean result = handle(exception);
+			if (result && exception instanceof InterruptedException)
+				Thread.currentThread().interrupt();
+			return result;
+		}
+		catch (Throwable e) {
+			// Using of sneak() can lead to InterruptedException here
+			if (exception instanceof InterruptedException
+					&& !(e instanceof InterruptedException)) {
+				Thread.currentThread().interrupt();
+			}
+			e.addSuppressed(exception);
+			throw e;
+		}
+	}
+
 	/**
 	 * Initialize new {@code ExceptionHandler}.
 	 */
@@ -93,7 +118,7 @@ public abstract class ExceptionHandler {
 			try {
 				runnable.run();
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 			}
 		}
@@ -123,7 +148,7 @@ public abstract class ExceptionHandler {
 			try {
 				return Optional.ofNullable(supplier.get());
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return Optional.empty();
 			}
@@ -154,7 +179,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalInt.of(supplier.getAsInt());
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalInt.empty();
 			}
@@ -185,7 +210,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalLong.of(supplier.getAsLong());
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalLong.empty();
 			}
@@ -216,7 +241,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalDouble.of(supplier.getAsDouble());
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalDouble.empty();
 			}
@@ -247,7 +272,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalBoolean.of(supplier.getAsBoolean());
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalBoolean.empty();
 			}
@@ -278,7 +303,7 @@ public abstract class ExceptionHandler {
 			try {
 				consumer.accept(t);
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 			}
 		}
@@ -308,7 +333,7 @@ public abstract class ExceptionHandler {
 			try {
 				consumer.accept(value);
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 			}
 		}
@@ -338,7 +363,7 @@ public abstract class ExceptionHandler {
 			try {
 				consumer.accept(value);
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 			}
 		}
@@ -368,7 +393,7 @@ public abstract class ExceptionHandler {
 			try {
 				consumer.accept(value);
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 			}
 		}
@@ -398,7 +423,7 @@ public abstract class ExceptionHandler {
 			try {
 				consumer.accept(t, u);
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 			}
 		}
@@ -428,7 +453,7 @@ public abstract class ExceptionHandler {
 			try {
 				consumer.accept(t, value);
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 			}
 		}
@@ -458,7 +483,7 @@ public abstract class ExceptionHandler {
 			try {
 				consumer.accept(t, value);
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 			}
 		}
@@ -488,7 +513,7 @@ public abstract class ExceptionHandler {
 			try {
 				consumer.accept(t, value);
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 			}
 		}
@@ -518,7 +543,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalBoolean.of(predicate.test(t));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalBoolean.empty();
 			}
@@ -549,7 +574,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalBoolean.of(predicate.test(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalBoolean.empty();
 			}
@@ -580,7 +605,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalBoolean.of(predicate.test(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalBoolean.empty();
 			}
@@ -611,7 +636,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalBoolean.of(predicate.test(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalBoolean.empty();
 			}
@@ -642,7 +667,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalBoolean.of(predicate.test(t, u));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalBoolean.empty();
 			}
@@ -673,7 +698,7 @@ public abstract class ExceptionHandler {
 			try {
 				return Optional.ofNullable(function.apply(t));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return Optional.empty();
 			}
@@ -704,7 +729,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalInt.of(function.applyAsInt(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalInt.empty();
 			}
@@ -735,7 +760,7 @@ public abstract class ExceptionHandler {
 			try {
 				return Optional.ofNullable(function.apply(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return Optional.empty();
 			}
@@ -766,7 +791,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalLong.of(function.applyAsLong(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalLong.empty();
 			}
@@ -797,7 +822,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalDouble.of(function.applyAsDouble(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalDouble.empty();
 			}
@@ -828,7 +853,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalLong.of(function.applyAsLong(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalLong.empty();
 			}
@@ -859,7 +884,7 @@ public abstract class ExceptionHandler {
 			try {
 				return Optional.ofNullable(function.apply(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return Optional.empty();
 			}
@@ -890,7 +915,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalInt.of(function.applyAsInt(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalInt.empty();
 			}
@@ -921,7 +946,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalDouble.of(function.applyAsDouble(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalDouble.empty();
 			}
@@ -952,7 +977,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalDouble.of(function.applyAsDouble(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalDouble.empty();
 			}
@@ -983,7 +1008,7 @@ public abstract class ExceptionHandler {
 			try {
 				return Optional.ofNullable(function.apply(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return Optional.empty();
 			}
@@ -1014,7 +1039,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalInt.of(function.applyAsInt(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalInt.empty();
 			}
@@ -1045,7 +1070,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalLong.of(function.applyAsLong(value));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalLong.empty();
 			}
@@ -1076,7 +1101,7 @@ public abstract class ExceptionHandler {
 			try {
 				return Optional.ofNullable(operator.apply(operand));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return Optional.empty();
 			}
@@ -1107,7 +1132,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalInt.of(operator.applyAsInt(operand));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalInt.empty();
 			}
@@ -1138,7 +1163,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalLong.of(operator.applyAsLong(operand));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalLong.empty();
 			}
@@ -1169,7 +1194,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalDouble.of(operator.applyAsDouble(operand));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalDouble.empty();
 			}
@@ -1200,7 +1225,7 @@ public abstract class ExceptionHandler {
 			try {
 				return Optional.ofNullable(function.apply(t, u));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return Optional.empty();
 			}
@@ -1231,7 +1256,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalInt.of(function.applyAsInt(t, u));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalInt.empty();
 			}
@@ -1262,7 +1287,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalLong.of(function.applyAsLong(t, u));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalLong.empty();
 			}
@@ -1293,7 +1318,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalDouble.of(function.applyAsDouble(t, u));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalDouble.empty();
 			}
@@ -1324,7 +1349,7 @@ public abstract class ExceptionHandler {
 			try {
 				return Optional.ofNullable(operator.apply(left, right));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return Optional.empty();
 			}
@@ -1355,7 +1380,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalInt.of(operator.applyAsInt(left, right));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalInt.empty();
 			}
@@ -1386,7 +1411,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalLong.of(operator.applyAsLong(left, right));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalLong.empty();
 			}
@@ -1417,7 +1442,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalDouble.of(operator.applyAsDouble(left, right));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalDouble.empty();
 			}
@@ -1448,7 +1473,7 @@ public abstract class ExceptionHandler {
 			try {
 				return OptionalInt.of(comparator.compare(left, right));
 			} catch (Throwable exception) {
-				if (!handle(exception))
+				if (!doHandle(exception))
 					throw exception;
 				return OptionalInt.empty();
 			}
@@ -1473,7 +1498,7 @@ public abstract class ExceptionHandler {
 		try {
 			runnable.run();
 		} catch (Throwable exception) {
-			if (!handle(exception))
+			if (!doHandle(exception))
 				throw exception;
 		}
 	}
@@ -1497,7 +1522,7 @@ public abstract class ExceptionHandler {
 		try {
 			return Optional.ofNullable(supplier.get());
 		} catch (Throwable exception) {
-			if (!handle(exception))
+			if (!doHandle(exception))
 				throw exception;
 			return Optional.empty();
 		}
@@ -1522,7 +1547,7 @@ public abstract class ExceptionHandler {
 		try {
 			return OptionalInt.of(supplier.getAsInt());
 		} catch (Throwable exception) {
-			if (!handle(exception))
+			if (!doHandle(exception))
 				throw exception;
 			return OptionalInt.empty();
 		}
@@ -1547,7 +1572,7 @@ public abstract class ExceptionHandler {
 		try {
 			return OptionalLong.of(supplier.getAsLong());
 		} catch (Throwable exception) {
-			if (!handle(exception))
+			if (!doHandle(exception))
 				throw exception;
 			return OptionalLong.empty();
 		}
@@ -1572,7 +1597,7 @@ public abstract class ExceptionHandler {
 		try {
 			return OptionalDouble.of(supplier.getAsDouble());
 		} catch (Throwable exception) {
-			if (!handle(exception))
+			if (!doHandle(exception))
 				throw exception;
 			return OptionalDouble.empty();
 		}
@@ -1597,7 +1622,7 @@ public abstract class ExceptionHandler {
 		try {
 			return OptionalBoolean.of(supplier.getAsBoolean());
 		} catch (Throwable exception) {
-			if (!handle(exception))
+			if (!doHandle(exception))
 				throw exception;
 			return OptionalBoolean.empty();
 		}

--- a/src/main/java/com/machinezoo/noexception/ExceptionTransform.java
+++ b/src/main/java/com/machinezoo/noexception/ExceptionTransform.java
@@ -1,12 +1,14 @@
 // Part of NoException: https://noexception.machinezoo.com
 package com.machinezoo.noexception;
 
+import java.util.Optional;
 import java.util.function.*;
 import lombok.*;
 
-@RequiredArgsConstructor final class ExceptionTransform extends CheckedExceptionHandler {
+@RequiredArgsConstructor final class ExceptionTransform extends ExceptionWrapper {
 	@NonNull private final Function<Exception, RuntimeException> wrapper;
-	@Override public RuntimeException handle(@NonNull Exception exception) {
-		return wrapper.apply(exception);
+	@Override protected RuntimeException wrap(Exception exception) {
+		return Optional.ofNullable(wrapper.apply(exception))
+				.orElse(super.wrap(exception));
 	}
 }

--- a/src/main/java/com/machinezoo/noexception/ExceptionWrapper.java
+++ b/src/main/java/com/machinezoo/noexception/ExceptionWrapper.java
@@ -3,8 +3,15 @@ package com.machinezoo.noexception;
 
 import lombok.*;
 
-final class ExceptionWrapper extends CheckedExceptionHandler {
-	@Override public RuntimeException handle(@NonNull Exception exception) {
+class ExceptionWrapper extends CheckedExceptionHandler {
+	protected RuntimeException wrap(Exception exception) {
 		return new WrappedException(exception);
+	}
+
+	@Override public final RuntimeException handle(@NonNull Exception exception) {
+		// Because of we catched InterruptedException, we must restore interrupt status
+		if (exception instanceof InterruptedException)
+			Thread.currentThread().interrupt();
+		return wrap(exception);
 	}
 }

--- a/src/test/java/com/machinezoo/noexception/ExceptionHandlerDoHandleTest.java
+++ b/src/test/java/com/machinezoo/noexception/ExceptionHandlerDoHandleTest.java
@@ -1,0 +1,112 @@
+package com.machinezoo.noexception;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static com.machinezoo.noexception.Exceptions.sneak;
+import static com.machinezoo.noexception.InterruptedAsserts.assertThatThreadInterruptedIsNotSet;
+import static com.machinezoo.noexception.InterruptedAsserts.assertThatThreadInterruptedIsSet;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class ExceptionHandlerDoHandleTest {
+    @Rule public ExpectedException expectedException = ExpectedException.none();
+
+    private ExceptionHandler exceptionHandler;
+
+    @Before public void setUp() {
+        exceptionHandler = spy(ExceptionHandler.class);
+    }
+
+    @Test public void handle_accept_exception() {
+        when(exceptionHandler.handle(any(Throwable.class)))
+                .thenReturn(true);
+
+        assertTrue(exceptionHandler.doHandle(new NumberFormatException()));
+    }
+
+    @Test public void handle_throw_exception() {
+        doThrow(new IllegalArgumentException())
+                .when(exceptionHandler)
+                .handle(any(Throwable.class));
+
+        expectedException.expect(
+                both(instanceOf(IllegalArgumentException.class))
+                        .and(hasProperty("suppressed", hasItemInArray(instanceOf(NumberFormatException.class)))));
+
+        exceptionHandler.doHandle(new NumberFormatException());
+    }
+
+    @Test public void handle_reject_exception() {
+        when(exceptionHandler.handle(any(Throwable.class)))
+                .thenReturn(false);
+
+        assertFalse(exceptionHandler.doHandle(new NumberFormatException()));
+    }
+
+    @Test public void handle_accept_InterruptedException() {
+        when(exceptionHandler.handle(any(InterruptedException.class)))
+                .thenReturn(true);
+        Thread.interrupted();
+
+        exceptionHandler.doHandle(new InterruptedException());
+
+        assertThatThreadInterruptedIsSet();
+    }
+
+    @Test public void handle_throw_not_InterrruptedException() {
+        doThrow(new NumberFormatException())
+                .when(exceptionHandler)
+                .handle(any(InterruptedException.class));
+        Thread.interrupted();
+
+        try {
+            exceptionHandler.doHandle(new InterruptedException());
+            fail();
+        }
+        catch (Throwable ignored) {
+        }
+
+        assertThatThreadInterruptedIsSet();
+    }
+
+    @Test public void handle_throw_InterrruptedException() {
+        when(exceptionHandler.handle(any(InterruptedException.class)))
+                .thenAnswer(a -> {
+                    sneak().run(() -> {
+                        throw new InterruptedException();
+                    });
+                    return true;
+                });
+        Thread.interrupted();
+
+        try {
+            exceptionHandler.doHandle(new InterruptedException());
+            fail();
+        } catch (Throwable ignored) {
+        }
+
+        assertThatThreadInterruptedIsNotSet();
+    }
+
+    @Test public void handle_reject_InterruptedException() {
+        when(exceptionHandler.handle(any(InterruptedException.class)))
+                .thenReturn(false);
+        Thread.interrupted();
+
+        exceptionHandler.doHandle(new InterruptedException());
+
+        assertThatThreadInterruptedIsNotSet();
+    }
+}

--- a/src/test/java/com/machinezoo/noexception/ExceptionHandlerTest.java
+++ b/src/test/java/com/machinezoo/noexception/ExceptionHandlerTest.java
@@ -18,11 +18,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void runnable_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		collector.runnable(() -> {
 			throw new NumberFormatException();
 		}).run();
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void runnable_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -35,6 +36,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void supplier_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") Supplier<String> lambda = mock(Supplier.class);
@@ -44,11 +46,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void supplier_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(Optional.empty(), collector.supplier(() -> {
 			throw new NumberFormatException();
 		}).get());
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void supplier_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -61,6 +64,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromIntSupplier_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		IntSupplier lambda = mock(IntSupplier.class);
@@ -70,11 +74,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromIntSupplier_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalInt.empty(), collector.fromIntSupplier(() -> {
 			throw new NumberFormatException();
 		}).get());
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromIntSupplier_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -87,6 +92,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromLongSupplier_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		LongSupplier lambda = mock(LongSupplier.class);
@@ -96,11 +102,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromLongSupplier_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalLong.empty(), collector.fromLongSupplier(() -> {
 			throw new NumberFormatException();
 		}).get());
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromLongSupplier_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -113,6 +120,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromDoubleSupplier_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		DoubleSupplier lambda = mock(DoubleSupplier.class);
@@ -122,11 +130,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromDoubleSupplier_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalDouble.empty(), collector.fromDoubleSupplier(() -> {
 			throw new NumberFormatException();
 		}).get());
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromDoubleSupplier_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -139,6 +148,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromBooleanSupplier_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		BooleanSupplier lambda = mock(BooleanSupplier.class);
@@ -148,11 +158,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromBooleanSupplier_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalBoolean.empty(), collector.fromBooleanSupplier(() -> {
 			throw new NumberFormatException();
 		}).get());
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromBooleanSupplier_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -165,6 +176,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void consumer_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") Consumer<String> lambda = mock(Consumer.class);
@@ -173,11 +185,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void consumer_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		collector.consumer(t -> {
 			throw new NumberFormatException();
 		}).accept("input");
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void consumer_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -190,6 +203,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromIntConsumer_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		IntConsumer lambda = mock(IntConsumer.class);
@@ -198,11 +212,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromIntConsumer_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		collector.fromIntConsumer(v -> {
 			throw new NumberFormatException();
 		}).accept(1);
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromIntConsumer_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -215,6 +230,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromLongConsumer_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		LongConsumer lambda = mock(LongConsumer.class);
@@ -223,7 +239,7 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromLongConsumer_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		collector.fromLongConsumer(v -> {
 			throw new NumberFormatException();
 		}).accept(1L);
@@ -240,6 +256,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromDoubleConsumer_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		DoubleConsumer lambda = mock(DoubleConsumer.class);
@@ -248,11 +265,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromDoubleConsumer_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		collector.fromDoubleConsumer(v -> {
 			throw new NumberFormatException();
 		}).accept(1.0);
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromDoubleConsumer_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -265,6 +283,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromBiConsumer_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") BiConsumer<String, String> lambda = mock(BiConsumer.class);
@@ -273,11 +292,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromBiConsumer_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		collector.fromBiConsumer((t, u) -> {
 			throw new NumberFormatException();
 		}).accept("input1", "input2");
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromBiConsumer_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -290,6 +310,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromObjIntConsumer_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") ObjIntConsumer<String> lambda = mock(ObjIntConsumer.class);
@@ -298,11 +319,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromObjIntConsumer_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		collector.fromObjIntConsumer((t, v) -> {
 			throw new NumberFormatException();
 		}).accept("input", 1);
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromObjIntConsumer_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -315,6 +337,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromObjLongConsumer_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") ObjLongConsumer<String> lambda = mock(ObjLongConsumer.class);
@@ -323,11 +346,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromObjLongConsumer_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		collector.fromObjLongConsumer((t, v) -> {
 			throw new NumberFormatException();
 		}).accept("input", 1L);
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromObjLongConsumer_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -340,6 +364,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromObjDoubleConsumer_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") ObjDoubleConsumer<String> lambda = mock(ObjDoubleConsumer.class);
@@ -348,11 +373,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromObjDoubleConsumer_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		collector.fromObjDoubleConsumer((t, v) -> {
 			throw new NumberFormatException();
 		}).accept("input", 1.0);
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromObjDoubleConsumer_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -365,6 +391,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void predicate_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") Predicate<String> lambda = mock(Predicate.class);
@@ -374,11 +401,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void predicate_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalBoolean.empty(), collector.predicate(t -> {
 			throw new NumberFormatException();
 		}).test("input"));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void predicate_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -391,6 +419,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromIntPredicate_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		IntPredicate lambda = mock(IntPredicate.class);
@@ -400,11 +429,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromIntPredicate_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalBoolean.empty(), collector.fromIntPredicate(v -> {
 			throw new NumberFormatException();
 		}).test(1));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromIntPredicate_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -417,6 +447,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromLongPredicate_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		LongPredicate lambda = mock(LongPredicate.class);
@@ -426,11 +457,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromLongPredicate_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalBoolean.empty(), collector.fromLongPredicate(v -> {
 			throw new NumberFormatException();
 		}).test(1L));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromLongPredicate_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -443,6 +475,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromDoublePredicate_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		DoublePredicate lambda = mock(DoublePredicate.class);
@@ -452,11 +485,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromDoublePredicate_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalBoolean.empty(), collector.fromDoublePredicate(v -> {
 			throw new NumberFormatException();
 		}).test(1.0));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromDoublePredicate_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -469,6 +503,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromBiPredicate_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") BiPredicate<String, String> lambda = mock(BiPredicate.class);
@@ -478,11 +513,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromBiPredicate_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalBoolean.empty(), collector.fromBiPredicate((t, u) -> {
 			throw new NumberFormatException();
 		}).test("input1", "input2"));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromBiPredicate_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -495,6 +531,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void function_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") Function<String, String> lambda = mock(Function.class);
@@ -504,11 +541,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void function_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(Optional.empty(), collector.function(t -> {
 			throw new NumberFormatException();
 		}).apply("input"));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void function_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -521,6 +559,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromToIntFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") ToIntFunction<String> lambda = mock(ToIntFunction.class);
@@ -530,11 +569,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromToIntFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalInt.empty(), collector.fromToIntFunction(v -> {
 			throw new NumberFormatException();
 		}).apply("input"));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromToIntFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -547,6 +587,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromIntFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") IntFunction<String> lambda = mock(IntFunction.class);
@@ -556,11 +597,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromIntFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(Optional.empty(), collector.fromIntFunction(v -> {
 			throw new NumberFormatException();
 		}).apply(1));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromIntFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -573,6 +615,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromIntToLongFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		IntToLongFunction lambda = mock(IntToLongFunction.class);
@@ -582,11 +625,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromIntToLongFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalLong.empty(), collector.fromIntToLongFunction(v -> {
 			throw new NumberFormatException();
 		}).apply(1));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromIntToLongFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -599,6 +643,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromIntToDoubleFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		IntToDoubleFunction lambda = mock(IntToDoubleFunction.class);
@@ -608,11 +653,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromIntToDoubleFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalDouble.empty(), collector.fromIntToDoubleFunction(v -> {
 			throw new NumberFormatException();
 		}).apply(1));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromIntToDoubleFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -625,6 +671,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromToLongFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") ToLongFunction<String> lambda = mock(ToLongFunction.class);
@@ -634,11 +681,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromToLongFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalLong.empty(), collector.fromToLongFunction(v -> {
 			throw new NumberFormatException();
 		}).apply("input"));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromToLongFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -651,6 +699,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromLongFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") LongFunction<String> lambda = mock(LongFunction.class);
@@ -660,11 +709,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromLongFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(Optional.empty(), collector.fromLongFunction(v -> {
 			throw new NumberFormatException();
 		}).apply(1L));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromLongFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -677,6 +727,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromLongToIntFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		LongToIntFunction lambda = mock(LongToIntFunction.class);
@@ -686,11 +737,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromLongToIntFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalInt.empty(), collector.fromLongToIntFunction(v -> {
 			throw new NumberFormatException();
 		}).apply(1L));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromLongToIntFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -703,6 +755,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromLongToDoubleFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		LongToDoubleFunction lambda = mock(LongToDoubleFunction.class);
@@ -712,11 +765,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromLongToDoubleFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalDouble.empty(), collector.fromLongToDoubleFunction(v -> {
 			throw new NumberFormatException();
 		}).apply(1L));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromLongToDoubleFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -729,6 +783,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromToDoubleFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") ToDoubleFunction<String> lambda = mock(ToDoubleFunction.class);
@@ -738,11 +793,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromToDoubleFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalDouble.empty(), collector.fromToDoubleFunction(v -> {
 			throw new NumberFormatException();
 		}).apply("input"));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromToDoubleFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -755,6 +811,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromDoubleFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") DoubleFunction<String> lambda = mock(DoubleFunction.class);
@@ -764,11 +821,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromDoubleFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(Optional.empty(), collector.fromDoubleFunction(v -> {
 			throw new NumberFormatException();
 		}).apply(1.0));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromDoubleFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -781,6 +839,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromDoubleToIntFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		DoubleToIntFunction lambda = mock(DoubleToIntFunction.class);
@@ -790,11 +849,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromDoubleToIntFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalInt.empty(), collector.fromDoubleToIntFunction(v -> {
 			throw new NumberFormatException();
 		}).apply(1.0));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromDoubleToIntFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -807,6 +867,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromDoubleToLongFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		DoubleToLongFunction lambda = mock(DoubleToLongFunction.class);
@@ -816,11 +877,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromDoubleToLongFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalLong.empty(), collector.fromDoubleToLongFunction(v -> {
 			throw new NumberFormatException();
 		}).apply(1.0));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromDoubleToLongFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -833,6 +895,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromUnaryOperator_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") UnaryOperator<String> lambda = mock(UnaryOperator.class);
@@ -842,11 +905,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromUnaryOperator_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(Optional.empty(), collector.fromUnaryOperator(o -> {
 			throw new NumberFormatException();
 		}).apply("input"));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromUnaryOperator_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -859,6 +923,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromIntUnaryOperator_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		IntUnaryOperator lambda = mock(IntUnaryOperator.class);
@@ -868,11 +933,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromIntUnaryOperator_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalInt.empty(), collector.fromIntUnaryOperator(o -> {
 			throw new NumberFormatException();
 		}).apply(1));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromIntUnaryOperator_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -885,6 +951,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromLongUnaryOperator_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		LongUnaryOperator lambda = mock(LongUnaryOperator.class);
@@ -894,11 +961,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromLongUnaryOperator_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalLong.empty(), collector.fromLongUnaryOperator(o -> {
 			throw new NumberFormatException();
 		}).apply(1L));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromLongUnaryOperator_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -911,6 +979,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromDoubleUnaryOperator_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		DoubleUnaryOperator lambda = mock(DoubleUnaryOperator.class);
@@ -920,11 +989,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromDoubleUnaryOperator_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalDouble.empty(), collector.fromDoubleUnaryOperator(o -> {
 			throw new NumberFormatException();
 		}).apply(1.0));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromDoubleUnaryOperator_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -937,6 +1007,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromBiFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") BiFunction<String, String, String> lambda = mock(BiFunction.class);
@@ -946,11 +1017,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromBiFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(Optional.empty(), collector.fromBiFunction((t, u) -> {
 			throw new NumberFormatException();
 		}).apply("input1", "input2"));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromBiFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -963,6 +1035,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromToIntBiFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") ToIntBiFunction<String, String> lambda = mock(ToIntBiFunction.class);
@@ -972,11 +1045,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromToIntBiFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalInt.empty(), collector.fromToIntBiFunction((t, u) -> {
 			throw new NumberFormatException();
 		}).apply("input1", "input2"));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromToIntBiFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -989,6 +1063,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromToLongBiFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") ToLongBiFunction<String, String> lambda = mock(ToLongBiFunction.class);
@@ -998,11 +1073,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromToLongBiFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalLong.empty(), collector.fromToLongBiFunction((t, u) -> {
 			throw new NumberFormatException();
 		}).apply("input1", "input2"));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromToLongBiFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -1015,6 +1091,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromToDoubleBiFunction_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") ToDoubleBiFunction<String, String> lambda = mock(ToDoubleBiFunction.class);
@@ -1024,11 +1101,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromToDoubleBiFunction_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalDouble.empty(), collector.fromToDoubleBiFunction((t, u) -> {
 			throw new NumberFormatException();
 		}).apply("input1", "input2"));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromToDoubleBiFunction_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -1041,6 +1119,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromBinaryOperator_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") BinaryOperator<String> lambda = mock(BinaryOperator.class);
@@ -1050,11 +1129,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromBinaryOperator_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(Optional.empty(), collector.fromBinaryOperator((l, r) -> {
 			throw new NumberFormatException();
 		}).apply("input1", "input2"));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromBinaryOperator_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -1067,6 +1147,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromIntBinaryOperator_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		IntBinaryOperator lambda = mock(IntBinaryOperator.class);
@@ -1076,11 +1157,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromIntBinaryOperator_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalInt.empty(), collector.fromIntBinaryOperator((l, r) -> {
 			throw new NumberFormatException();
 		}).apply(11, 12));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromIntBinaryOperator_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -1093,6 +1175,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromLongBinaryOperator_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		LongBinaryOperator lambda = mock(LongBinaryOperator.class);
@@ -1102,11 +1185,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromLongBinaryOperator_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalLong.empty(), collector.fromLongBinaryOperator((l, r) -> {
 			throw new NumberFormatException();
 		}).apply(11L, 12L));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromLongBinaryOperator_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -1119,6 +1203,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void fromDoubleBinaryOperator_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		DoubleBinaryOperator lambda = mock(DoubleBinaryOperator.class);
@@ -1128,11 +1213,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void fromDoubleBinaryOperator_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalDouble.empty(), collector.fromDoubleBinaryOperator((l, r) -> {
 			throw new NumberFormatException();
 		}).apply(1.1, 1.2));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void fromDoubleBinaryOperator_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -1145,6 +1231,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void comparator_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") Comparator<String> lambda = mock(Comparator.class);
@@ -1154,11 +1241,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void comparator_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalInt.empty(), collector.comparator((l, r) -> {
 			throw new NumberFormatException();
 		}).compare("input1", "input2"));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void comparator_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -1171,6 +1259,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void run_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		Runnable lambda = mock(Runnable.class);
@@ -1179,11 +1268,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void run_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		collector.run(() -> {
 			throw new NumberFormatException();
 		});
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void run_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -1196,6 +1286,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void get_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		@SuppressWarnings("unchecked") Supplier<String> lambda = mock(Supplier.class);
@@ -1205,11 +1296,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void get_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(Optional.empty(), collector.get(() -> {
 			throw new NumberFormatException();
 		}));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void get_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -1222,6 +1314,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void getAsInt_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		IntSupplier lambda = mock(IntSupplier.class);
@@ -1231,11 +1324,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void getAsInt_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalInt.empty(), collector.getAsInt(() -> {
 			throw new NumberFormatException();
 		}));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void getAsInt_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -1248,6 +1342,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void getAsLong_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		LongSupplier lambda = mock(LongSupplier.class);
@@ -1257,11 +1352,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void getAsLong_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalLong.empty(), collector.getAsLong(() -> {
 			throw new NumberFormatException();
 		}));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void getAsLong_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -1274,6 +1370,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void getAsDouble_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		DoubleSupplier lambda = mock(DoubleSupplier.class);
@@ -1283,11 +1380,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void getAsDouble_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalDouble.empty(), collector.getAsDouble(() -> {
 			throw new NumberFormatException();
 		}));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void getAsDouble_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);
@@ -1300,6 +1398,7 @@ public class ExceptionHandlerTest {
 		}
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
 	}
+
 	@Test public void getAsBoolean_complete() {
 		ExceptionCollector collector = new ExceptionCollector(true);
 		BooleanSupplier lambda = mock(BooleanSupplier.class);
@@ -1309,11 +1408,12 @@ public class ExceptionHandlerTest {
 		assertTrue(collector.empty());
 	}
 	@Test public void getAsBoolean_swallowException() {
-		ExceptionCollector collector = new ExceptionCollector(true);
+		ExceptionCollector collector = spy(new ExceptionCollector(true));
 		assertEquals(OptionalBoolean.empty(), collector.getAsBoolean(() -> {
 			throw new NumberFormatException();
 		}));
 		assertThat(collector.single(), instanceOf(NumberFormatException.class));
+		verify(collector).doHandle(any());
 	}
 	@Test public void getAsBoolean_passException() {
 		ExceptionCollector collector = new ExceptionCollector(false);

--- a/src/test/java/com/machinezoo/noexception/ExceptionsTest.java
+++ b/src/test/java/com/machinezoo/noexception/ExceptionsTest.java
@@ -1,6 +1,7 @@
 // Part of NoException: https://noexception.machinezoo.com
 package com.machinezoo.noexception;
 
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.*;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -21,6 +22,7 @@ public class ExceptionsTest {
 			throw new IOError(new IOException());
 		});
 	}
+
 	@Test public void silence_runtime() {
 		Exceptions.silence().run(() -> {
 			throw new NumberFormatException();
@@ -31,6 +33,7 @@ public class ExceptionsTest {
 			throw new IOError(new IOException());
 		});
 	}
+
 	@Test(expected = NumberFormatException.class) public void sneak_runtime() {
 		Exceptions.sneak().run(() -> {
 			throw new NumberFormatException();
@@ -46,6 +49,7 @@ public class ExceptionsTest {
 			throw new IOException();
 		});
 	}
+
 	@Test(expected = NumberFormatException.class) public void wrap_runtime() {
 		Exceptions.wrap().run(() -> {
 			throw new NumberFormatException();
@@ -61,10 +65,23 @@ public class ExceptionsTest {
 			Exceptions.wrap().run(() -> {
 				throw new IOException();
 			});
+			fail();
 		} catch (WrappedException e) {
 			assertThat(e.getCause(), instanceOf(IOException.class));
 		}
 	}
+	@Test public void wrap_InterruptedException() {
+		try {
+			Exceptions.wrap().run(() -> {
+				throw new InterruptedException();
+			});
+			fail();
+		} catch (WrappedException e) {
+			assertThat(e.getCause(), instanceOf(InterruptedException.class));
+			checkAndClearInterruptStatus();
+		}
+	}
+
 	@Test(expected = NumberFormatException.class) public void wrapIn_runtime() {
 		Exceptions.wrap(CollectedException::new).run(() -> {
 			throw new NumberFormatException();
@@ -80,10 +97,28 @@ public class ExceptionsTest {
 			Exceptions.wrap(CollectedException::new).run(() -> {
 				throw new IOException();
 			});
+			fail();
 		} catch (CollectedException e) {
 			assertThat(e.getCause(), instanceOf(IOException.class));
 		}
 	}
+	@Test(expected = WrappedException.class) public void wrapIn_checked_not_mapped() {
+		Exceptions.wrap(e -> null).run(() -> {
+			throw new IOException();
+		});
+	}
+	@Test public void wrapIn_InterruptedException() {
+		try {
+			Exceptions.wrap(CollectedException::new).run(() -> {
+				throw new InterruptedException();
+			});
+			fail();
+		} catch (CollectedException e) {
+			assertThat(e.getCause(), instanceOf(InterruptedException.class));
+			checkAndClearInterruptStatus();
+		}
+	}
+
 	@Test public void log_runtime() {
 		Exceptions.log().run(() -> {
 			throw new NumberFormatException();
@@ -94,6 +129,7 @@ public class ExceptionsTest {
 			throw new IOError(new IOException());
 		});
 	}
+
 	@Test public void logTo() {
 		Logger logger = mock(Logger.class);
 		Exceptions.log(logger).run(() -> {
@@ -101,11 +137,19 @@ public class ExceptionsTest {
 		});
 		verify(logger, only()).error(eq("Caught exception"), any(NumberFormatException.class));
 	}
+
 	@Test public void logTWithMessage() {
 		Logger logger = mock(Logger.class);
 		Exceptions.log(logger, "Commented exception").run(() -> {
 			throw new NumberFormatException();
 		});
 		verify(logger, only()).error(eq("Commented exception"), any(NumberFormatException.class));
+	}
+
+	private static void checkAndClearInterruptStatus() {
+		assertThat(
+				"Interrupt status is not restored",
+				Thread.interrupted(), // We must clear interrupt status
+				is(true));
 	}
 }

--- a/src/test/java/com/machinezoo/noexception/ExceptionsTest.java
+++ b/src/test/java/com/machinezoo/noexception/ExceptionsTest.java
@@ -1,7 +1,7 @@
 // Part of NoException: https://noexception.machinezoo.com
 package com.machinezoo.noexception;
 
-import static org.hamcrest.core.Is.is;
+import static com.machinezoo.noexception.InterruptedAsserts.assertThatThreadInterruptedIsSet;
 import static org.hamcrest.core.IsInstanceOf.*;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -71,6 +71,7 @@ public class ExceptionsTest {
 		}
 	}
 	@Test public void wrap_InterruptedException() {
+		Thread.interrupted(); // Clear Thread.interrupted() flag
 		try {
 			Exceptions.wrap().run(() -> {
 				throw new InterruptedException();
@@ -78,7 +79,7 @@ public class ExceptionsTest {
 			fail();
 		} catch (WrappedException e) {
 			assertThat(e.getCause(), instanceOf(InterruptedException.class));
-			checkAndClearInterruptStatus();
+			assertThatThreadInterruptedIsSet();
 		}
 	}
 
@@ -108,6 +109,7 @@ public class ExceptionsTest {
 		});
 	}
 	@Test public void wrapIn_InterruptedException() {
+		Thread.interrupted(); // Clear Thread.interrupted() flag
 		try {
 			Exceptions.wrap(CollectedException::new).run(() -> {
 				throw new InterruptedException();
@@ -115,7 +117,7 @@ public class ExceptionsTest {
 			fail();
 		} catch (CollectedException e) {
 			assertThat(e.getCause(), instanceOf(InterruptedException.class));
-			checkAndClearInterruptStatus();
+			assertThatThreadInterruptedIsSet();
 		}
 	}
 
@@ -144,12 +146,5 @@ public class ExceptionsTest {
 			throw new NumberFormatException();
 		});
 		verify(logger, only()).error(eq("Commented exception"), any(NumberFormatException.class));
-	}
-
-	private static void checkAndClearInterruptStatus() {
-		assertThat(
-				"Interrupt status is not restored",
-				Thread.interrupted(), // We must clear interrupt status
-				is(true));
 	}
 }

--- a/src/test/java/com/machinezoo/noexception/InterruptedAsserts.java
+++ b/src/test/java/com/machinezoo/noexception/InterruptedAsserts.java
@@ -1,0 +1,20 @@
+package com.machinezoo.noexception;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class InterruptedAsserts {
+    public static void assertThatThreadInterruptedIsSet() {
+        assertThat(
+                "Interrupted status is not set",
+                Thread.interrupted(), // We must clear interrupt status
+                is(true));
+    }
+
+    public static void assertThatThreadInterruptedIsNotSet() {
+        assertThat(
+                "Interrupted status is set",
+                Thread.interrupted(), // We must clear interrupt status
+                is(false));
+    }
+}


### PR DESCRIPTION
We need special processing for InterruptedException. If we will be wrapping this exception and will not be restoring interrupted status for the thread pool thread, then we may broke the termination of this thread pool 